### PR TITLE
update org site with hiring notices for PostDoc and PreDoc

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -70,3 +70,7 @@
 
     </ul>
 
+**QuantEcon is hiring in 2017.** Position descriptions are now available for a `PostDoc <https://drive.google.com/file/d/0Bx9LyXzJWN5iUzNoNDcyVC1UM00/view?usp=sharing>`_ and a `PreDoc <https://drive.google.com/file/d/0Bx9LyXzJWN5iRVVnODM1NmdqcE0/view?usp=sharing>`_. 
+
+Please send any expressions of interest to contact@quantecon.org
+

--- a/index.rst
+++ b/index.rst
@@ -70,7 +70,17 @@
 
     </ul>
 
-**QuantEcon is hiring in 2017.** Position descriptions are now available for a `PostDoc <https://drive.google.com/file/d/0Bx9LyXzJWN5iUzNoNDcyVC1UM00/view?usp=sharing>`_ and a `PreDoc <https://drive.google.com/file/d/0Bx9LyXzJWN5iRVVnODM1NmdqcE0/view?usp=sharing>`_. 
 
-Please send any expressions of interest to contact@quantecon.org
+.. raw:: html
+	
+	<br>
+	<hr>
+
+**QuantEcon is hiring in 2017.** 
+
+.. raw:: html
+	
+	<hr>
+
+Position descriptions are now available for a `PostDoc <https://drive.google.com/file/d/0Bx9LyXzJWN5iUzNoNDcyVC1UM00/view?usp=sharing>`_ and a `PreDoc <https://drive.google.com/file/d/0Bx9LyXzJWN5iRVVnODM1NmdqcE0/view?usp=sharing>`_. These positions are based at The Australian National University (ANU) in Canberra, Australia. Please send any expressions of interest to contact@quantecon.org
 

--- a/index.rst
+++ b/index.rst
@@ -73,7 +73,6 @@
 
 .. raw:: html
 	
-	<br>
 	<hr>
 
 **QuantEcon is hiring in 2017.** 


### PR DESCRIPTION
This adds a simple notice on the front page for the upcoming PostDoc and PreDoc positions at QuantEcon

![image](https://cloud.githubusercontent.com/assets/8263752/21873796/1e89719c-d8c5-11e6-951e-f559414295e9.png)

The position descriptions are hosted on google drive.