### PR TITLE
Adding news generating infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build/
 _backup/
+news/
 
 *.pyc
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_static/QuantEcon.news"]
+	path = _static/QuantEcon.news
+	url = https://github.com/QuantEcon/QuantEcon.news.git

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ news:
 
 html:
 	@echo "Constructing news snippets from QuantEcon.news ..."
+	make update
 	make news
 	@echo
 	@echo "Building notebooks pages from notebooks.yaml ..."

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don not have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 
 # Internal variables.
@@ -19,7 +19,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext news
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -51,9 +51,29 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
+setup:
+	@echo "Running python tasks.py ..."
+	python tasks.py
+
+update:
+	@echo "Updating git submodules ..."
+	git submodule foreach git pull origin master
+
+### --- Make Supporting News Pages --- ###
+
+news:
+	@echo "[QuantEcon.news] Building HTML and RST News Pages from news.yaml"
+	cd _static/QuantEcon.news && make news	
+	cp ./_static/QuantEcon.news/org_site/news.rst ./news/
+	cp ./_static/QuantEcon.news/org_site/news_snippet.html ./news/
+
 html:
-	@echo "Building notebooks pages from notebooks.yaml"
+	@echo "Constructing news snippets from QuantEcon.news ..."
+	make news
+	@echo
+	@echo "Building notebooks pages from notebooks.yaml ..."
 	python build_nbgallery_rst.py
+	@echo
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo "Adjusting Front Page Title"
 	sed -i 's/&lt;no title&gt; &ndash; //g' $(BUILDDIR)/html/index.html

--- a/index.rst
+++ b/index.rst
@@ -41,6 +41,7 @@
     organizations.
     </p>
 
+   <div style=" display: flex; justify-content: center; "> <div style=" color: #31708f; background-color: #d9edf7; margin: 2em auto 0 auto; padding: 7px 15px; border: 1px solid #bce8f1; border-radius: 4px; font-size: 0.9em; "><strong>QuantEcon is hiring in 2017.</strong> Position descriptions are now available for a <a class="reference external" href="https://drive.google.com/file/d/0Bx9LyXzJWN5iUzNoNDcyVC1UM00/view?usp=sharing">PostDoc</a> and a <a class="reference external" href="https://drive.google.com/file/d/0Bx9LyXzJWN5iRVVnODM1NmdqcE0/view?usp=sharing">PreDoc</a>.</div></div>
 
     <ul id="coa-home">
         <li>
@@ -70,10 +71,8 @@
 
     </ul>
 
-
 .. raw:: html
-	
-	<hr>
+  :file: news/news_snippet.html
 
 **QuantEcon is hiring in 2017.** 
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,10 @@
+#-Tasks File for QuantEcon.site-#
+
+import os
+
+NEWS_BUILD_DIR = "news"
+
+# Check for a news directory
+if not os.path.exists(NEWS_BUILD_DIR):
+    print("Cannot find a news build directory (%s) ... creating one now"%NEWS_BUILD_DIR)
+    os.makedirs(NEWS_BUILD_DIR)


### PR DESCRIPTION
This PR

  1. adds ``QuantEcon.news`` as a git submodule
  1. adds commands for generating both a ``news.rst`` and ``news_snippet.html`` into a ``news`` build directory for incorporation into the site's ``index.html``
  1. adds a setup function which checks for the ``news`` build directory which is useful when setting up ``QuantEcon.site`` fresh for the first time. 

**Note:** The ``make html`` option now includes a submodule update request. This may fail if building offline. This is usually not the case but we could introduce ``make publish`` in similar fashion to lectures.quantecon.org if this is important for robustness.