### PR TITLE
add hosted page for web developer

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -26,6 +26,7 @@
    404
    team
    chicago_fed_workshop
+   job-web-developer
 
 .. include:: org_banner.raw
 

--- a/job-web-developer.rst
+++ b/job-web-developer.rst
@@ -1,0 +1,50 @@
+.. include:: org_banner.raw
+
+Position Description: Full Stack Web Developer
+==============================================
+
+Part-Time Contract (Hours Flexible)
+-----------------------------------
+
+We are looking for a computer science student with backend server/linux skills to help build a user
+content generated platform for the QuantEcon project based at The Australian National University,
+Research School of Economics. This project involves a contract for initial build, testing, and launch
+of the web platform. We are also interested in issuing a subsequent ongoing maintenance contract
+addressing issues and developing new functionality and features over the next 12 to 24 months.
+The QuantEcon notebook archive is a web based platform with the aim to encourage international
+collaboration and discussion in economics using Jupyter notebooks. We are currently developing a
+fully functional front end prototype (using Javascript and CSS) and a detailed function specification
+to help guide the successful applicant to develop the backend server software. The aim is to design
+a robust and scalable platform based on the Amazon AWS stack. The successful applicant would
+work with our key web designer, along with the QuantEcon team, and have the opportunity to
+identify and define key technologies that would be used on the server side.
+
+Selection Criteria & Skills
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Solid knowledge of modern Javascript
+2. Experience with Angular, React, or other Javascript frameworks is preferred
+3. Proficiency with source control using Git and Github
+4. Knowledge of AWS infrastructure (EC2, CloudFront, DNS, Load Balancing, Elastic server management) is preferrable
+5. Knowledge of scalability issues associated with web based projects
+6. Ability to work under limited supervision, with the ability to work remotely
+
+If this opportunity sounds interesting, please send through a resume and single page cover letter
+introducing yourself. The cover letter should detail your relevant skills and address each item of the
+selection criteria above. If you have further questions about this opportunity please contact Matthew 
+McKay at jobs@quantecon.org.
+
+Additional information about the project
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+QuantEcon (https://quantecon.org/) is an open source, not-for-profit organization dedicated to
+development and documentation of modern open source computational tools for economics,
+econometrics, and decision making.
+
+**Stage I** of the QuantEcon notebook archive will require:
+
+- User authentication using a social network (Github, Google, Facebook, Twitter, LinkedIn)
+- Form allowing users to submit a Jupyter Notebook file
+- Rendering of Jupyter Notebook submissions
+- Submission listing with topic/language filtering, sorting, and ranking algorithms
+- Voting on submissions
+- Threaded commenting on each submission with voting on posts


### PR DESCRIPTION
This page is **not** linked to any of the main pages of QuantEcon. 

This will be used through direct link on some notice boards. 