### PR TITLE
change link to krusell-smith notebooks

### DIFF
--- a/notebooks.yaml
+++ b/notebooks.yaml
@@ -283,4 +283,4 @@
         title: Solving the Krusell-Smith aggregate shocks model using Julia
         authors: Shunsuke Hori
         date: 12 May 2017
-        julia: http://nbviewer.jupyter.org/github/QuantEcon/krusell_smith_code/blob/master/KrusellSmith.ipynb
+        julia: http://nbviewer.jupyter.org/github/QuantEcon/QuantEcon.notebooks/blob/master/KrusellSmith.ipynb


### PR DESCRIPTION
 @jstac I think linking to the QuantEcon.notebooks repository is more consistent.